### PR TITLE
New alternative way to add SEB keys from django.conf.settings

### DIFF
--- a/seb_openedx/middleware.py
+++ b/seb_openedx/middleware.py
@@ -6,7 +6,6 @@ from django.http import HttpResponseForbidden
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
 from seb_openedx.permissions import AlwaysAllowStaff, CheckSEBKeys
-from seb_openedx.edxapp_wrapper.get_course_module import get_course_module
 
 
 class SecureExamBrowserMiddleware(MiddlewareMixin):
@@ -20,9 +19,8 @@ class SecureExamBrowserMiddleware(MiddlewareMixin):
         course_key_string = view_kwargs.get('course_key_string') or view_kwargs.get('course_id')
         course_key = CourseKey.from_string(course_key_string) if course_key_string else None
         if course_key:
-            course_module = get_course_module(course_key, depth=0)
             for permission in self.allow:
-                if permission().check(request, course_module):
+                if permission().check(request, course_key):
                     return
             return HttpResponseForbidden("Access Forbidden: This course can only be accessed with Safe Exam Browser")
 

--- a/seb_openedx/permissions.py
+++ b/seb_openedx/permissions.py
@@ -1,20 +1,21 @@
 """ Permissions as classes """
 import abc
 from django.utils import six
+from seb_openedx.seb_keys_sources import ORDERED_SEB_KEYS_SOURCES
 
 
 @six.add_metaclass(abc.ABCMeta)
 class Permission(object):
     """ Abstract class Permision """
     @abc.abstractmethod
-    def check(self, request, course_module):
+    def check(self, request, course_key):
         """ Abstract method check """
         pass
 
 
 class AlwaysAllowStaff(Permission):
     """ Always allow when user.is_staff """
-    def check(self, request, course_module):
+    def check(self, request, course_key):
         """ check """
         if hasattr(request, 'user') and request.user.is_authenticated() and request.user.is_staff:
             return True
@@ -23,11 +24,13 @@ class AlwaysAllowStaff(Permission):
 
 class CheckSEBKeys(Permission):
     """ Check for SEB keys, allow if there are none configured """
-    def check(self, request, course_module):
+    def check(self, request, course_key):
         """ check """
-        other_settings = course_module.other_course_settings
         header = 'HTTP_X_SAFEEXAMBROWSER_CONFIGKEYHASH'
-        if 'seb_keys' in other_settings and other_settings['seb_keys']:
-            return bool(header in request.META and request.META[header] in other_settings['seb_keys'])
-        # Courses without seb are allowed for everyone
+
+        for source_function in ORDERED_SEB_KEYS_SOURCES:
+            seb_keys = source_function(course_key)
+            if seb_keys:
+                return bool(request.META.get(header, None) in seb_keys)
+        # Courses without seb are allowed by default
         return True

--- a/seb_openedx/seb_keys_sources.py
+++ b/seb_openedx/seb_keys_sources.py
@@ -1,0 +1,35 @@
+"""
+SEB KEYS FETCHING
+Available functions that can be used to fetch Secure Exam Browser keys
+"""
+from django.conf import settings
+from seb_openedx.edxapp_wrapper.get_course_module import get_course_module
+
+
+def from_other_course_settings(course_key):
+    """
+    ENABLE_OTHER_COURSE_SETTINGS must be enabled for this option to work,
+    meaning Open edX version >= release-2018-08-07-11.59 (e.g. Hawtorn doesn't work)
+    """
+    course_module = get_course_module(course_key, depth=0)
+    if hasattr(course_module, 'other_course_settings'):
+        other_settings = course_module.other_course_settings
+        return other_settings.get('seb_keys', None)
+    return None
+
+
+def from_global_settings(course_key):
+    """
+    Retrieve from global settings, for example:
+    # lms/env/common.py
+    SEB_KEYS = {
+        "course-v1:edX+DemoX+Demo_Course": ["FAKE_SEB_KEY"]
+    }
+    """
+    if hasattr(settings, 'SEB_KEYS'):
+        return settings.SEB_KEYS.get(course_key, None)
+    return None
+
+
+# First one has precedence over second, second over third and so forth.
+ORDERED_SEB_KEYS_SOURCES = [from_global_settings, from_other_course_settings]

--- a/seb_openedx/tests/test_middleware.py
+++ b/seb_openedx/tests/test_middleware.py
@@ -21,24 +21,20 @@ class TestMiddleware(TestCase):
         self.superuser = get_user_model().objects.create_superuser('test', 'test@example.com', 'test')
         self.course_params = {"course_key_string": "library-v1:TestX+lib1"}
 
-    @mock.patch('seb_openedx.edxapp_wrapper.get_course_module.import_module')
-    def test_middleware_forbidden(self, m_import):
+    def test_middleware_forbidden(self):
         """ Test that middleware returns forbidden when there is no class handling allowed requests """
         SecureExamBrowserMiddleware.allow = []
         request = self.factory.get(self.url_pattern)
         response = self.seb_middleware.process_view(request, self.view, [], self.course_params)
         self.assertEqual(response.status_code, 403)
-        m_import.assert_called_with(settings.EOX_CORE_COURSE_MODULE)
 
-    @mock.patch('seb_openedx.edxapp_wrapper.get_course_module.import_module')
-    def test_middleware_is_staff(self, m_import):
+    def test_middleware_is_staff(self):
         """ Test that middleware returns None if user is admin (is_staff) """
         SecureExamBrowserMiddleware.allow = [AlwaysAllowStaff]
         request = self.factory.get(self.url_pattern)
         request.user = self.superuser
         response = self.seb_middleware.process_view(request, self.view, [], self.course_params)
         self.assertEqual(response, None)
-        m_import.assert_called_with(settings.EOX_CORE_COURSE_MODULE)
 
     @mock.patch('seb_openedx.edxapp_wrapper.get_course_module.import_module', side_effect=lambda x: FakeModuleForSebkeysTesting())
     def test_middleware_sebkeys(self, m_import):


### PR DESCRIPTION
As in:
```python
# edx-platform/lms/envs/common.py
SEB_KEYS = {
    "course-v1:edX+DemoX+Demo_Course": ["FAKE_SEB_KEY"]
}
```