### PR TITLE
Support SEB_KEYS read from the settings json file

### DIFF
--- a/seb_openedx/settings/common.py
+++ b/seb_openedx/settings/common.py
@@ -29,3 +29,10 @@ def plugin_settings(settings):
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
     settings.EOX_CORE_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'
+    settings.SEB_KEYS = getattr(settings, "SEB_KEYS", {})
+    
+    if not settings.SEB_KEYS:
+        try:
+            settings.SEB_KEYS = settings.ENV_TOKENS.get('SEB_KEYS', {})
+        except AttributeError:
+            pass

--- a/seb_openedx/settings/common.py
+++ b/seb_openedx/settings/common.py
@@ -28,11 +28,8 @@ def plugin_settings(settings):
     Defines seb_openedx settings when app is used as a plugin to edx-platform.
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    settings.EOX_CORE_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'
-    settings.SEB_KEYS = getattr(settings, "SEB_KEYS", {})
+    settings.EOX_CORE_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'    
     
-    if not settings.SEB_KEYS:
-        try:
-            settings.SEB_KEYS = settings.ENV_TOKENS.get('SEB_KEYS', {})
-        except AttributeError:
-            pass
+    if not hasattr(settings, 'SEB_KEYS'):
+        settings.SEB_KEYS = getattr(settings, 'ENV_TOKENS', {}).get('SEB_KEYS', {})
+        


### PR DESCRIPTION
This PR changes the settings module so that it supports setting the SEB_KEYS at the json file that ansible can edit, without having to alter the aws.py file from the edx-platform code.
