### PR TITLE
Make this actually work at all...

### DIFF
--- a/seb_openedx/middleware.py
+++ b/seb_openedx/middleware.py
@@ -5,13 +5,13 @@ from django.utils.deprecation import MiddlewareMixin
 from django.http import HttpResponseForbidden
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
-from seb_openedx.permissions import AlwaysAllowStaff, CheckSEBKeys
+from seb_openedx.permissions import AlwaysAllowStaff, CheckSEBKeysRequestHash
 
 
 class SecureExamBrowserMiddleware(MiddlewareMixin):
     """ Middleware for seb_openedx """
 
-    allow = [AlwaysAllowStaff, CheckSEBKeys]
+    allow = [AlwaysAllowStaff, CheckSEBKeysRequestHash]
 
     # pylint: disable=inconsistent-return-statements
     def process_view(self, request, view_func, view_args, view_kwargs):

--- a/seb_openedx/seb_keys_sources.py
+++ b/seb_openedx/seb_keys_sources.py
@@ -2,6 +2,7 @@
 SEB KEYS FETCHING
 Available functions that can be used to fetch Secure Exam Browser keys
 """
+from django.utils import six
 from django.conf import settings
 from seb_openedx.edxapp_wrapper.get_course_module import get_course_module
 
@@ -27,7 +28,7 @@ def from_global_settings(course_key):
     }
     """
     if hasattr(settings, 'SEB_KEYS'):
-        return settings.SEB_KEYS.get(course_key, None)
+        return settings.SEB_KEYS.get(six.text_type(course_key), None)
     return None
 
 

--- a/seb_openedx/settings/common.py
+++ b/seb_openedx/settings/common.py
@@ -28,8 +28,7 @@ def plugin_settings(settings):
     Defines seb_openedx settings when app is used as a plugin to edx-platform.
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    settings.EOX_CORE_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'    
-    
+    settings.EOX_CORE_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'
+
     if not hasattr(settings, 'SEB_KEYS'):
         settings.SEB_KEYS = getattr(settings, 'ENV_TOKENS', {}).get('SEB_KEYS', {})
-        


### PR DESCRIPTION
Make this actually work at all when using HTTP_X_SAFEEXAMBROWSER_REQUESTHASH

**TODO:** The implementation of the new way, meaning when using header [HTTP_X_SAFEEXAMBROWSER_CONFIGKEY](https://www.safeexambrowser.org/developer/seb-config-key.html)