### PR TITLE
Remove mentions of eox-core

### DIFF
--- a/seb_openedx/edxapp_wrapper/get_course_module.py
+++ b/seb_openedx/edxapp_wrapper/get_course_module.py
@@ -6,7 +6,7 @@ from django.conf import settings
 def get_course_module(*args, **kwargs):
     """ Creates the edxapp user """
 
-    backend_function = settings.EOX_CORE_COURSE_MODULE
+    backend_function = settings.SEB_COURSE_MODULE
     backend = import_module(backend_function)
 
     return backend.get_course_module(*args, **kwargs)

--- a/seb_openedx/settings/common.py
+++ b/seb_openedx/settings/common.py
@@ -28,5 +28,5 @@ def plugin_settings(settings):
     Defines seb_openedx settings when app is used as a plugin to edx-platform.
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    settings.EOX_CORE_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'
+    settings.SEB_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'
     settings.SEB_CONFIGURATION_HELPERS = 'seb_openedx.edxapp_wrapper.backends.get_configuration_helpers_h_v1'

--- a/seb_openedx/tests/test_middleware.py
+++ b/seb_openedx/tests/test_middleware.py
@@ -46,7 +46,7 @@ class TestMiddleware(TestCase):
         request.META['HTTP_X_SAFEEXAMBROWSER_REQUESTHASH'] = hashlib.sha256(tohash).hexdigest()
         response = self.seb_middleware.process_view(request, self.view, [], {"course_key_string": "library-v1:TestX+lib1"})
         self.assertEqual(response, None)
-        m_import.assert_called_with(settings.EOX_CORE_COURSE_MODULE)
+        m_import.assert_called_with(settings.SEB_COURSE_MODULE)
 
 
 class FakeModuleForSebkeysTesting(object):


### PR DESCRIPTION
Fix erroneously named constants prefixed with "EOX_CORE", now prefixing with "SEB" instead