### PR TITLE
Make SEB plugin more configuration-based

### DIFF
--- a/seb_openedx/edxapp_wrapper/backends/edxmako_module_h_v1.py
+++ b/seb_openedx/edxapp_wrapper/backends/edxmako_module_h_v1.py
@@ -3,7 +3,7 @@ import os
 import edxmako  # pylint: disable=import-error
 
 
-def render_to_response(self, template_name, dictionary=None, namespace='main', request=None, **kwargs):
+def render_to_response(template_name, dictionary=None, namespace='main', request=None, **kwargs):
     """ Custom render_to_response implementation using configurable backend and adding template dir """
     if os.path.dirname(os.path.abspath(__file__)) + '/templates' not in edxmako.LOOKUP['main'].directories:
         edxmako.paths.add_lookup('main', 'templates', 'seb_openedx')

--- a/seb_openedx/seb_keys_sources.py
+++ b/seb_openedx/seb_keys_sources.py
@@ -44,5 +44,9 @@ def from_site_configuration(course_key):
     return None
 
 
-# First one has precedence over second, second over third and so forth.
-ORDERED_SEB_KEYS_SOURCES = [from_global_settings, from_other_course_settings, from_site_configuration]
+def get_ordered_seb_keys_sources():
+    """ get key sources as specified on settings, or the default ones """
+    # First one has precedence over second, second over third and so forth.
+    if hasattr(settings, 'SEB_KEY_SOURCES'):
+        return [globals()[source] for source in settings.SEB_KEY_SOURCES]
+    return [from_global_settings, from_other_course_settings, from_site_configuration]

--- a/seb_openedx/settings/common.py
+++ b/seb_openedx/settings/common.py
@@ -31,3 +31,5 @@ def plugin_settings(settings):
     settings.SEB_COURSE_MODULE = 'seb_openedx.edxapp_wrapper.backends.get_course_module_h_v1'
     settings.SEB_CONFIGURATION_HELPERS = 'seb_openedx.edxapp_wrapper.backends.get_configuration_helpers_h_v1'
     settings.SEB_EDXMAKO_MODULE = 'seb_openedx.edxapp_wrapper.backends.edxmako_module_h_v1'
+    settings.SEB_PERMISSION_COMPONENTS = ['AlwaysAllowStaff', 'CheckSEBKeysRequestHash']
+    settings.SEB_KEY_SOURCES = ['from_global_settings', 'from_other_course_settings', 'from_site_configuration']

--- a/seb_openedx/tests/test_middleware.py
+++ b/seb_openedx/tests/test_middleware.py
@@ -5,8 +5,8 @@ import mock
 from django.test import RequestFactory, TestCase
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.test.utils import override_settings
 from seb_openedx.middleware import SecureExamBrowserMiddleware
-from seb_openedx.permissions import AlwaysAllowStaff, CheckSEBKeysRequestHash
 
 
 class TestMiddleware(TestCase):
@@ -23,25 +23,25 @@ class TestMiddleware(TestCase):
         self.course_params = {"course_key_string": "library-v1:TestX+lib1"}
 
     @mock.patch('seb_openedx.middleware.render_to_response')
+    @override_settings(SEB_PERMISSION_COMPONENTS=[])
     def test_middleware_forbidden(self, m_render_to_response):
         """ Test that middleware returns forbidden when there is no class handling allowed requests """
-        SecureExamBrowserMiddleware.allow = []
         request = self.factory.get(self.url_pattern)
         self.seb_middleware.process_view(request, self.view, [], self.course_params)
         m_render_to_response.assert_called_once_with('seb-403.html', status=403)
 
+    @override_settings(SEB_PERMISSION_COMPONENTS=['AlwaysAllowStaff'])
     def test_middleware_is_staff(self):
         """ Test that middleware returns None if user is admin (is_staff) """
-        SecureExamBrowserMiddleware.allow = [AlwaysAllowStaff]
         request = self.factory.get(self.url_pattern)
         request.user = self.superuser
         response = self.seb_middleware.process_view(request, self.view, [], self.course_params)
         self.assertEqual(response, None)
 
     @mock.patch('seb_openedx.edxapp_wrapper.get_course_module.import_module', side_effect=lambda x: FakeModuleForSebkeysTesting())
+    @override_settings(SEB_PERMISSION_COMPONENTS=['CheckSEBKeysRequestHash'])
     def test_middleware_sebkeys(self, m_import):
         """ Test that middleware returns None when valid seb key is given """
-        SecureExamBrowserMiddleware.allow = [CheckSEBKeysRequestHash]
         request = self.factory.get(self.url_pattern)
         tohash = request.build_absolute_uri().encode() + FakeModuleForSebkeysTesting.other_course_settings['seb_keys'][0].encode()
         request.META['HTTP_X_SAFEEXAMBROWSER_REQUESTHASH'] = hashlib.sha256(tohash).hexdigest()


### PR DESCRIPTION
Clearly stating from django.config.settings:

SEB_PERMISSION_COMPONENTS: What is the order and availability of key_sources (global, other_settings), example:
`SEB_PERMISSION_COMPONENTS = ['AlwaysAllowStaff', 'CheckSEBKeysRequestHash']`

SEB_KEY_SOURCES: What permission classes are enable, example:
`SEB_KEY_SOURCES = ['from_global_settings', 'from_other_course_settings', 'from_site_configuration']`