### PR TITLE
Making whitelisting and blacklisting per course settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ On studio Settings.FEATURES['ENABLE_OTHER_COURSE_SETTINGS'] must be enabled, the
 You can specify which tabs/parts of the course are always allowed; and if you need to be more specific you can blacklist specific chapters as well.
 Example allowing all tabs but denying access to a specific "chapter":
 ```python
-settings.SEB_WHITELIST_PATHS = ['wiki', 'course-outline', 'courseware', 'progress', 'discussion']
-settings.SEB_BLACKLIST_CHAPTERS = ['d8a6192ade314473a78242dfeedfbf5b']
+SEB_KEYS = {
+    "course-v1:edX+DemoX+Demo_Course": {
+        "BROWSER_KEYS": ["EXAMPLEHASHPROVIDEDBYSEB"],
+        "WHITELIST_PATHS": ['wiki', 'course-outline', 'courseware', 'progress', 'discussion'],
+        "BLACKLIST_CHAPTERS": ['d8a6192ade314473a78242dfeedfbf5b'],
+    },
+    "course-v1:edX+E2E-101+course": ["ANOTHEREXAMPLEHASHPROVIDEDBYSEB"]
+}
 ```
 
 ## Development

--- a/seb_openedx/middleware.py
+++ b/seb_openedx/middleware.py
@@ -6,6 +6,7 @@ import inspect
 from django.http import HttpResponseNotFound
 from django.utils.deprecation import MiddlewareMixin
 from django.conf import settings
+from django.utils.six import text_type
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 from seb_openedx.edxapp_wrapper.edxmako_module import render_to_string, render_to_response
@@ -16,8 +17,8 @@ from seb_openedx.edxapp_wrapper.get_chapter_from_location import get_chapter_fro
 from seb_openedx.user_banning import is_user_banned, ban_user
 from seb_openedx.permissions import get_enabled_permission_classes
 
-SEB_WHITELIST_PATHS = getattr(settings, 'SEB_WHITELIST_PATHS', [])
-SEB_BLACKLIST_CHAPTERS = getattr(settings, 'SEB_BLACKLIST_CHAPTERS', [])
+
+SEB_KEYS = getattr(settings, 'SEB_KEYS', {})
 BANNING_ENABLED = getattr(settings, 'SEB_USER_BANNING_ENABLED', True)
 
 
@@ -40,14 +41,17 @@ class SecureExamBrowserMiddleware(MiddlewareMixin):
         if course_key:
             # By default is all denied
             access_denied = True
+            config = SEB_KEYS.get(text_type(course_key), {})
 
-            if self.is_whitelisted_view(request, course_key):
-                # First: Broad white-listing
-                access_denied = False
+            if isinstance(config, dict):
+                # Only dict configuration has whitelisting/blacklisting
+                if self.is_whitelisted_view(config, request, course_key):
+                    # First: Broad white-listing
+                    access_denied = False
 
-            if self.is_blacklisted_chapter(request, course_key):
-                # Second: Granular black-listing
-                access_denied = True
+                if self.is_blacklisted_chapter(config, request, course_key):
+                    # Second: Granular black-listing
+                    access_denied = True
 
             user_name, masquerade, context = self.handle_masquerade(request, course_key)
 
@@ -99,7 +103,7 @@ class SecureExamBrowserMiddleware(MiddlewareMixin):
             return self.courseware_error_response(request, context, *view_args, **view_kwargs)
         return self.generic_error_response(request, course_key, context)
 
-    def is_whitelisted_view(self, request, course_key):
+    def is_whitelisted_view(self, config, request, course_key):
         """ First broad filter: whitelisting of paths/tabs """
 
         # Whitelisting logic by alias
@@ -112,38 +116,43 @@ class SecureExamBrowserMiddleware(MiddlewareMixin):
         views_module = inspect.getmodule(request.resolver_match.func).__name__
         paths_matched = [aliases[key] for key in aliases if views_module.startswith(key)]
         alias_current_path = paths_matched[0] if paths_matched else None
+        whitelist_paths = config.get('WHITELIST_PATHS', [])
 
-        if alias_current_path in SEB_WHITELIST_PATHS:
+        if not whitelist_paths:
+            return False
+
+        if alias_current_path in whitelist_paths:
             return True
 
         # Whitelisting xblocks when courseware
-        if 'courseware' in SEB_WHITELIST_PATHS and self.is_xblock_request(request):
+        if 'courseware' in whitelist_paths and self.is_xblock_request(request):
             return True
 
         # Whitelisting by url name
         if request.resolver_match.url_name:
-            url_names_allowed = list(SEB_WHITELIST_PATHS) + ['jump_to', 'jump_to_id']
+            url_names_allowed = list(whitelist_paths) + ['jump_to', 'jump_to_id']
             for url_name in url_names_allowed:
                 if request.resolver_match.url_name.startswith(url_name):
                     return True
 
         return False
 
-    def is_blacklisted_chapter(self, request, course_key):
+    def is_blacklisted_chapter(self, config, request, course_key):
         """ Second more granular filter: blacklisting of specific chapters """
         chapter = request.resolver_match.kwargs.get('chapter')
+        blackist_chapters = config.get('BLACKLIST_CHAPTERS', [])
 
-        if not SEB_BLACKLIST_CHAPTERS:
+        if not blackist_chapters:
             return False
 
-        if chapter in SEB_BLACKLIST_CHAPTERS:
+        if chapter in blackist_chapters:
             return True
 
-        if 'courseware' in SEB_WHITELIST_PATHS and self.is_xblock_request(request):
+        if 'courseware' in config.get('WHITELIST_PATHS', []) and self.is_xblock_request(request):
             usage_id = request.resolver_match.kwargs.get('usage_id')
             if usage_id:
                 chapter = get_chapter_from_location(usage_id, course_key)
-                if chapter in SEB_BLACKLIST_CHAPTERS:
+                if chapter in blackist_chapters:
                     return True
         return False
 

--- a/seb_openedx/permissions.py
+++ b/seb_openedx/permissions.py
@@ -34,6 +34,8 @@ class CheckSEBKeysRequestHash(Permission):
         header = 'HTTP_X_SAFEEXAMBROWSER_REQUESTHASH'
         for source_function in ordered_seb_keys_sources:
             seb_keys = source_function(course_key)
+            if isinstance(seb_keys, dict) and 'BROWSER_KEYS' in seb_keys:
+                seb_keys = seb_keys['BROWSER_KEYS']
             if seb_keys:
                 header_value = request.META.get(header, None)
                 for key in seb_keys:

--- a/seb_openedx/seb_keys_sources.py
+++ b/seb_openedx/seb_keys_sources.py
@@ -16,7 +16,7 @@ def from_other_course_settings(course_key):
     course_module = get_course_module(course_key, depth=0)
     if hasattr(course_module, 'other_course_settings'):
         other_settings = course_module.other_course_settings
-        return other_settings.get('seb_keys', None)
+        return other_settings.get('SEB_KEYS', None)
     return None
 
 

--- a/seb_openedx/tests/test_middleware.py
+++ b/seb_openedx/tests/test_middleware.py
@@ -10,6 +10,7 @@ from django.test.utils import override_settings
 from seb_openedx.middleware import SecureExamBrowserMiddleware
 
 
+@patch.object(SecureExamBrowserMiddleware, 'get_config', Mock(return_value={}))
 @patch.object(SecureExamBrowserMiddleware, 'is_whitelisted_view', Mock(return_value=False))
 @patch.object(SecureExamBrowserMiddleware, 'is_blacklisted_chapter', Mock(return_value=True))
 @patch.object(SecureExamBrowserMiddleware, 'handle_masquerade', Mock(return_value=(None, None, {})))


### PR DESCRIPTION
Making whitelisting-paths and blacklisting-chapters configuration in a per course basis, example:
```
SEB_KEYS = {
    "course-v1:edX+DemoX+Demo_Course": {
        "BROWSER_KEYS": ["EXAMPLEHASHPROVIDEDBYSEB"],
        "WHITELIST_PATHS": ['wiki', 'course-outline', 'courseware', 'progress', 'discussion'],
        "BLACKLIST_CHAPTERS": ['d8a6192ade314473a78242dfeedfbf5b'],
    },
    "course-v1:edX+E2E-101+course": ["ANOTHEREXAMPLEHASHPROVIDEDBYSEB"]
}
```