### PR TITLE
Renaming SEB_KEYS for SAFE_EXAM_BROWSER

### DIFF
--- a/seb_openedx/seb_keys_sources.py
+++ b/seb_openedx/seb_keys_sources.py
@@ -16,7 +16,7 @@ def from_other_course_settings(course_key):
     course_module = get_course_module(course_key, depth=0)
     if hasattr(course_module, 'other_course_settings'):
         other_settings = course_module.other_course_settings
-        return other_settings.get('SEB_KEYS', None)
+        return other_settings.get('SAFE_EXAM_BROWSER', None)
     return None
 
 
@@ -24,12 +24,12 @@ def from_global_settings(course_key):
     """
     Retrieve from global settings, for example:
     # lms/env/common.py
-    SEB_KEYS = {
+    SAFE_EXAM_BROWSER = {
         "course-v1:edX+DemoX+Demo_Course": ["FAKE_SEB_KEY"]
     }
     """
-    if hasattr(settings, 'SEB_KEYS'):
-        return settings.SEB_KEYS.get(six.text_type(course_key), None)
+    if hasattr(settings, 'SAFE_EXAM_BROWSER'):
+        return settings.SAFE_EXAM_BROWSER.get(six.text_type(course_key), None)
     return None
 
 
@@ -38,8 +38,8 @@ def from_site_configuration(course_key):
     Get SEB keys from djangoapps.site_configuration
     """
     configuration_helpers = get_configuration_helpers()
-    if configuration_helpers.has_override_value('SEB_KEYS'):
-        keys_dict = configuration_helpers.get_configuration_value('SEB_KEYS')
+    if configuration_helpers.has_override_value('SAFE_EXAM_BROWSER'):
+        keys_dict = configuration_helpers.get_configuration_value('SAFE_EXAM_BROWSER')
         return keys_dict.get(six.text_type(course_key), None)
     return None
 

--- a/seb_openedx/settings/aws.py
+++ b/seb_openedx/settings/aws.py
@@ -10,5 +10,5 @@ def plugin_settings(settings):
     Defines seb_openedx settings when app is used as a plugin to edx-platform.
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    if not hasattr(settings, 'SEB_KEYS'):
-        settings.SEB_KEYS = getattr(settings, 'ENV_TOKENS', {}).get('SEB_KEYS', {})
+    if not hasattr(settings, 'SAFE_EXAM_BROWSER'):
+        settings.SAFE_EXAM_BROWSER = getattr(settings, 'ENV_TOKENS', {}).get('SAFE_EXAM_BROWSER', {})

--- a/seb_openedx/tests/test_permissions.py
+++ b/seb_openedx/tests/test_permissions.py
@@ -23,7 +23,7 @@ class TestPermissionClasses(TestCase):
         request.user.is_staff = False
         self.assertFalse(AlwaysAllowStaff().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["fake_browser_key"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["fake_browser_key"]})
     def test_browser_keys_no_key(self):
         """ Having no key hash results in access denied """
         request = Mock()
@@ -32,7 +32,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertFalse(CheckSEBHashBrowserExamKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_browser_keys_valid_key(self):
         """ Having a valid hash results in access granted """
         request = Mock()
@@ -43,7 +43,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertTrue(CheckSEBHashBrowserExamKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_browser_keys_invalid_key(self):
         """ Having an invalid hash results in access denied """
         request = Mock()
@@ -52,7 +52,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertFalse(CheckSEBHashBrowserExamKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["fake_config_key"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["fake_config_key"]})
     def test_config_keys_no_key(self):
         """ Having no key hash results in access denied """
         request = Mock()
@@ -61,7 +61,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertFalse(CheckSEBHashConfigKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_config_keys_valid_key(self):
         """ Having a valid hash results in access granted """
         request = Mock()
@@ -72,7 +72,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertTrue(CheckSEBHashConfigKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_config_keys_invalid_key(self):
         """ Having an invalid hash results in access denied """
         request = Mock()
@@ -81,7 +81,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertFalse(CheckSEBHashConfigKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_either_key_both_invalid(self):
         """ Having both invalid hashes results in access denied """
         request = Mock()
@@ -93,7 +93,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertFalse(CheckSEBHashBrowserExamKeyOrConfigKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_either_key_bek_valid(self):
         """ Having a valid Browser key results in access granted """
         request = Mock()
@@ -105,7 +105,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertTrue(CheckSEBHashBrowserExamKeyOrConfigKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_either_key_ck_valid(self):
         """ Having a valid Config key results in access granted """
         request = Mock()
@@ -117,7 +117,7 @@ class TestPermissionClasses(TestCase):
 
         self.assertTrue(CheckSEBHashBrowserExamKeyOrConfigKey().check(request, "fake_course_id"))
 
-    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SEB_KEYS={"fake_course_id": ["534b5a6a593e735e9d"]})
+    @override_settings(SEB_KEY_SOURCES=['from_global_settings'], SAFE_EXAM_BROWSER={"fake_course_id": ["534b5a6a593e735e9d"]})
     def test_either_key_both_valid(self):
         """ Having a valid Config key and valid Browser key results in access granted """
         request = Mock()


### PR DESCRIPTION
This PR changes the name where we store all the settings.

It has been growing for a while. By now it holds a lot more configs than just keys, and I figured it is better to take this shot now