### PR TITLE
Whitelisting the API module

### DIFF
--- a/seb_openedx/middleware.py
+++ b/seb_openedx/middleware.py
@@ -126,6 +126,9 @@ class SecureExamBrowserMiddleware(MiddlewareMixin):
         alias_current_path = paths_matched[0] if paths_matched else None
         whitelist_paths = config.get('WHITELIST_PATHS', [])
 
+        if views_module.startswith('seb_openedx.api'):
+            return True
+
         if not whitelist_paths:
             return False
 


### PR DESCRIPTION
The API has to be whitelisted since the authentication with Bearer token does not return the user with admin privileges on time