### PR TITLE
Add audit log decorator for configuration model

### DIFF
--- a/seb_openedx/audit.py
+++ b/seb_openedx/audit.py
@@ -1,0 +1,69 @@
+"""Custom audit log for seb_openedx"""
+
+import logging
+
+from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
+from django.contrib.contenttypes.models import ContentType
+from django.utils import six
+from django.db.utils import ProgrammingError
+from seb_openedx.constants import SEB_NOT_TABLES_FOUND
+from seb_openedx.models import SebCourseConfiguration
+
+LOG = logging.getLogger(__name__)
+
+
+def get_action(config, instance):
+    """Get the action by simulating the normal behavior of the function to_django_model."""
+    if config:
+        if instance:
+            return CHANGE
+        return ADDITION
+    return DELETION
+
+
+def get_change_message(data):
+    "Get the change message to be displayed in the admin."
+    data = {key.lower(): value for key, value in data.items()}  # keys to lowercase
+    message = ', '.join(data.keys())
+    return 'Changed {}'.format(message)
+
+
+def get_message(action, config):
+    """Choose the message for the admin depending on the action."""
+    message = {
+        ADDITION: 'Added.',
+        CHANGE: get_change_message(config),
+        DELETION: 'Deleted.'
+    }
+    return message.get(action)
+
+
+def audit_model(func):
+    """Decorator to use the LogEntry model from other sources, for the SebCourseConfiguration model."""
+    def wrapper(*args, **kwargs):
+        """Audits information if it successfully modifies the SebCourseConfiguration model."""
+        course_key = args[0]
+        config = args[1]
+        user_id = kwargs.get('user_id')
+        try:
+            instance = SebCourseConfiguration.objects.get(course_id=course_key)
+        except SebCourseConfiguration.DoesNotExist:
+            instance = None
+        except ProgrammingError:
+            LOG.warning(SEB_NOT_TABLES_FOUND)
+            return func(*args, **kwargs)
+        action = get_action(config, instance)
+        function = func(*args, **kwargs)
+        if function:
+            if not instance:
+                instance = SebCourseConfiguration.objects.get(course_id=course_key)
+            LogEntry.objects.log_action(
+                user_id=user_id,
+                content_type_id=ContentType.objects.get_for_model(SebCourseConfiguration).pk,
+                object_id=instance.id,
+                object_repr=six.text_type(instance.course_id),
+                action_flag=action,
+                change_message=get_message(action, config)
+            )
+        return function
+    return wrapper

--- a/seb_openedx/seb_keys_sources.py
+++ b/seb_openedx/seb_keys_sources.py
@@ -7,6 +7,7 @@ import logging
 from django.utils import six
 from django.conf import settings
 from django.db.utils import ProgrammingError
+from seb_openedx.audit import audit_model
 from seb_openedx.constants import SEPARATOR_CHAR, SEB_NOT_TABLES_FOUND, SEB_ARRAY_FIELDS_MODEL
 from seb_openedx.models import SebCourseConfiguration
 from seb_openedx.edxapp_wrapper.get_course_module import get_course_module, modulestore_update_item
@@ -98,6 +99,7 @@ def from_site_configuration(course_key):
     return None
 
 
+@audit_model
 def to_django_model(course_key, config, **kwargs):
     """
     Set SEB keys on SebCourseConfiguration


### PR DESCRIPTION
This allows using the django admin logs from the api, the result.

![image](https://user-images.githubusercontent.com/10764344/82239821-05d2b980-98ff-11ea-8597-087b98d688e0.png)
