### PR TITLE
Bump version: 1.3.1 → 2.0.0

### DIFF
--- a/seb_openedx/__init__.py
+++ b/seb_openedx/__init__.py
@@ -3,7 +3,7 @@ Init for main seb_openedx app
 """
 from __future__ import unicode_literals
 
-__version__ = '1.3.1'
+__version__ = '2.0.0'
 
 
 default_app_config = 'seb_openedx.apps.SebOpenEdxConfig'  # pylint: disable=invalid-name

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.1
+current_version = 2.0.0
 commit = True
 tag = True
 


### PR DESCRIPTION
This PR is a holder for the v2.0.0 tag.

We need this to go around the branch protection restriction