### PR TITLE
chore: adding tests for python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.11"]
         toxenv: [quality, pii_check, django32, django40]
 
     steps:


### PR DESCRIPTION
This PR adds python 3.11 to the test matrix