### PR TITLE
Using all the source keys

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -111,6 +111,11 @@ This is the list of variables that you can alter globally
 
     This setting controls the backend implementation for the mako renderer wrapper. Defaults to the hawthorn compatible implementation.
 
+- **SEB_USE_ALL_SOURCES**
+    Default: ``True``
+
+    This setting controls the whether the first source to return a key for a course should be used, of if all of them will be added in order.
+
 
 Key Hashes
 ==========

--- a/seb_openedx/permissions.py
+++ b/seb_openedx/permissions.py
@@ -55,13 +55,17 @@ class CheckSEBHash:
                 ]
             }
         """
+        all_keys = []
         for source_function in get_ordered_seb_keys_sources():
             seb_keys = source_function(course_key)
             if isinstance(seb_keys, dict):
                 seb_keys = seb_keys.get(self.detailed_config_key, None)
-            if seb_keys:
+            if seb_keys and settings.SEB_USE_ALL_SOURCES:
+                all_keys += seb_keys
+            elif seb_keys:
                 return seb_keys
-        return None
+
+        return all_keys
 
     def check(self, request, course_key, *args, **kwargs):
         """

--- a/seb_openedx/permissions.py
+++ b/seb_openedx/permissions.py
@@ -65,7 +65,7 @@ class CheckSEBHash:
             elif seb_keys:
                 return seb_keys
 
-        return all_keys
+        return list(set(all_keys))
 
     def check(self, request, course_key, *args, **kwargs):
         """

--- a/seb_openedx/permissions.py
+++ b/seb_openedx/permissions.py
@@ -28,6 +28,7 @@ class AlwaysAllowStaff(Permission):
         if masquerade and masquerade.role != 'staff':
             return False
         if hasattr(request, 'user') and request.user.is_authenticated and request.user.is_staff:
+            LOG.info("SEB AlwaysAllowStaff check passed for user: %s", request.user)
             return True
         return False
 

--- a/seb_openedx/seb_keys_sources.py
+++ b/seb_openedx/seb_keys_sources.py
@@ -92,6 +92,30 @@ def from_global_settings(course_key):
     return None
 
 
+def from_global_settings_default_keys(*args):
+    """
+    Retrieve from global settings using the default key, ignores course_key, for example:
+    # lms/env/common.py
+    SAFE_EXAM_BROWSER = {
+        "default": ["FAKE_SEB_KEY"]
+    }
+    """
+    if hasattr(settings, 'SAFE_EXAM_BROWSER'):
+        return settings.SAFE_EXAM_BROWSER.get('default', None)
+    return None
+
+
+def from_site_configuration_default_keys(*args):
+    """
+    Get SEB keys from djangoapps.site_configuration ignoring course_key and using the default
+    """
+    configuration_helpers = get_configuration_helpers()
+    if configuration_helpers.has_override_value('SAFE_EXAM_BROWSER'):
+        keys_dict = configuration_helpers.get_configuration_value('SAFE_EXAM_BROWSER')
+        return keys_dict.get('default', None)
+    return None
+
+
 def from_site_configuration(course_key):
     """
     Get SEB keys from djangoapps.site_configuration

--- a/seb_openedx/settings/common.py
+++ b/seb_openedx/settings/common.py
@@ -42,6 +42,8 @@ def plugin_settings(settings):
         'from_other_course_settings',
         'from_django_model',
         'from_site_configuration',
+        'from_global_settings_default_keys',
+        'from_site_configuration_default_keys',
     ]
     settings.SEB_KEY_DESTINATIONS = ['to_django_model', 'to_other_course_settings', 'to_site_configuration']
 

--- a/seb_openedx/settings/common.py
+++ b/seb_openedx/settings/common.py
@@ -46,6 +46,7 @@ def plugin_settings(settings):
     settings.SEB_KEY_DESTINATIONS = ['to_django_model', 'to_other_course_settings', 'to_site_configuration']
 
     # When SEB determines the access is denied one may specify what to whitelist/blacklist more granularly
+    settings.SEB_USE_ALL_SOURCES = True
     settings.SEB_WHITELIST_PATHS = []
     settings.SEB_BLACKLIST_CHAPTERS = []
     # Options include 'DatabaseBannedUsersBackend' and 'UserprofileBannedUsersBackend' (not yet implemented)

--- a/seb_openedx/settings/production.py
+++ b/seb_openedx/settings/production.py
@@ -60,3 +60,7 @@ def plugin_settings(settings):
         'SEB_USER_BANNING_ENABLED',
         settings.SEB_USER_BANNING_ENABLED
     )
+    settings.SEB_USE_ALL_SOURCES = getattr(settings, 'ENV_TOKENS', {}).get(
+        'SEB_USE_ALL_SOURCES',
+        settings.SEB_USE_ALL_SOURCES
+    )


### PR DESCRIPTION
This PR adds a feature to allow for all the source keys to be added as a list instead of just using the first source that returns a key

