### PR TITLE
block individual xblock

### DIFF
--- a/seb_openedx/middleware.py
+++ b/seb_openedx/middleware.py
@@ -8,7 +8,7 @@ import logging
 from django.http import HttpResponseNotFound
 from django.utils.deprecation import MiddlewareMixin
 from django.conf import settings
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from web_fragments.fragment import Fragment
 from seb_openedx.edxapp_wrapper.edxmako_module import render_to_string, render_to_response
 from seb_openedx.edxapp_wrapper.get_courseware_module import get_courseware_module
@@ -37,6 +37,10 @@ class SecureExamBrowserMiddleware(MiddlewareMixin):
         course_key_string = view_kwargs.get('course_key_string') or view_kwargs.get('course_id')
         course_key = CourseKey.from_string(course_key_string) if course_key_string else None
 
+        if course_key is None:
+            usage_key_string = view_kwargs.get('usage_key_string')
+            usage_key = UsageKey.from_string(usage_key_string) if usage_key_string else None
+            course_key = usage_key.course_key if usage_key else None
         # When the request is for masquerade (ajax) we leave it alone
         if self.get_view_path(request) == 'courseware.masquerade':
             return None

--- a/seb_openedx/middleware.py
+++ b/seb_openedx/middleware.py
@@ -232,7 +232,10 @@ class SecureExamBrowserMiddleware(MiddlewareMixin):
 
     def is_xblock_request(self, request):
         """ returns if it's an xblock HTTP request or not """
-        return request.resolver_match.func.__name__ == 'handle_xblock_callback'
+        return any([
+            request.resolver_match.func.__name__ == 'handle_xblock_callback',
+            request.resolver_match.func.__name__ == 'render_xblock',
+        ])
 
     def get_view_path(self, request):
         """ get full import path of match resolver """

--- a/seb_openedx/templates/seb-xblock.html
+++ b/seb_openedx/templates/seb-xblock.html
@@ -1,0 +1,72 @@
+<%page expression_filter="h"/>
+<%inherit file="/main.html" />
+<%namespace name='static' file='/static_content.html'/>
+<%!
+from django.utils.translation import gettext as _
+
+from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangolib.js_utils import js_escaped_string
+%>
+
+
+<%block name="headextra">
+<%static:css group='style-course-vendor'/>
+<%static:css group='style-course'/>
+</%block>
+
+
+
+<%block name="body_extra"/>
+
+<div class="course-wrapper chromeless">
+  <section class="course-content" id="course-content"\
+    style="display: block; width: auto; margin: 0;"
+  >
+      <main id="main" aria-label="Content">
+        <h1><%block name="pageheader">${_("Error: Access not allowed")}</%block></h1>
+        <p style="text-align: center;">
+            <%block name="pagecontent">
+                ${Text(_('This section can only be accessed with "Safe Exam Browser"'))}
+            </%block>
+        </p>
+        <p style="text-align: center;">
+            % if is_new_ban:
+                ${Text(_('Additionally you have been banned, you may ask your teacher or systems administrator to unblock you.'))}
+            % elif banned:
+                ${Text(_('You are banned from accessing the course, you may ask your teacher or systems administrator to unblock you.'))}
+            % endif
+        </p>
+      </main>
+  </section>
+</div>
+
+<script type="text/javascript">
+  (function() {
+    // If this view is rendered in an iframe within the learning microfrontend app
+    // it will report the height of its contents to the parent window when the
+    // document loads, window resizes, or DOM mutates.
+    if (window !== window.parent) {
+      document.body.className += ' view-in-mfe';
+      var lastHeight = window.offsetHeight;
+      var lastWidth = window.offsetWidth;
+      var contentElement = document.getElementById('content');
+
+      function dispatchResizeMessage(event) {
+        // Note: event is actually an Array of MutationRecord objects when fired from the MutationObserver
+        var isLoadEvent = event.type === 'load';
+        var newHeight = contentElement.offsetHeight;
+        var newWidth = contentElement.offsetWidth;
+
+        window.parent.postMessage({
+            type: 'plugin.resize',
+            payload: {
+              width: newWidth,
+              height: newHeight,
+            }
+          }, document.referrer
+        );
+      }
+      window.addEventListener('load', dispatchResizeMessage);
+    }
+  }());
+</script>

--- a/seb_openedx/templates/seb-xblock.html
+++ b/seb_openedx/templates/seb-xblock.html
@@ -47,13 +47,10 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     // document loads, window resizes, or DOM mutates.
     if (window !== window.parent) {
       document.body.className += ' view-in-mfe';
-      var lastHeight = window.offsetHeight;
-      var lastWidth = window.offsetWidth;
       var contentElement = document.getElementById('content');
 
       function dispatchResizeMessage(event) {
         // Note: event is actually an Array of MutationRecord objects when fired from the MutationObserver
-        var isLoadEvent = event.type === 'load';
         var newHeight = contentElement.offsetHeight;
         var newWidth = contentElement.offsetWidth;
 


### PR DESCRIPTION
This PR makes it possible to put a seb restriction in an individual page.

It will correctly allow for blocking of a url of the form:
http://local.edly.io:8000/xblock/block-v1:Demo+Demo+test+type@vertical+block@d30d79a1f41445cdb6125de70a88ff7d?exam_access=&recheck_access=1&show_bookmark=0&show_title=0&view=student_view

Replaces #66